### PR TITLE
Updates march10 v1

### DIFF
--- a/.github/pages/README.md
+++ b/.github/pages/README.md
@@ -1,0 +1,45 @@
+# Test Dashboard
+
+This directory contains the Test Results Dashboard that gets deployed to GitHub Pages.
+
+## What it does
+
+- **Dashboard (`dashboard.html`)**: Landing page showing test trends and history
+- **Test History**: Tracks pass/fail rates, duration, and links to detailed reports
+- **Trend Charts**: Visualizes test metrics over time using Chart.js
+
+## How it works
+
+1. After each test run, Playwright generates a JSON report (`test-results.json`)
+2. The `extract-test-metrics.js` script parses the results and updates `test-history.json`
+3. Each test run is stored in a dated folder: `reports/YYYY-MM-DD-run-###/`
+4. The dashboard reads `test-history.json` and renders trends and links
+5. Everything is deployed to GitHub Pages at: `https://pagelsr.github.io/GinosGelato/`
+
+## File Structure (on gh-pages branch)
+
+```
+/
+├── index.html              (Dashboard)
+├── test-history.json       (All test run metrics)
+├── current-run-summary.json
+└── reports/
+    ├── 2026-03-10-run-123/
+    │   └── index.html      (Detailed Playwright report)
+    ├── 2026-03-11-run-124/
+    └── ...
+```
+
+## Features
+
+- ✅ Pass/Fail trend chart (last 20 runs)
+- ✅ Duration trend chart
+- ✅ Summary statistics (total runs, avg pass rate)
+- ✅ Recent test runs table with direct links
+- ✅ Keeps last 50 runs in history
+- ✅ Mobile responsive design
+
+## Viewing Reports
+
+- **Dashboard**: https://pagelsr.github.io/GinosGelato/
+- **Specific Run**: https://pagelsr.github.io/GinosGelato/reports/2026-03-10-run-123/

--- a/.github/pages/dashboard.html
+++ b/.github/pages/dashboard.html
@@ -1,0 +1,424 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Gino's Gelato - Test Dashboard</title>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+    
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: #333;
+      padding: 20px;
+      min-height: 100vh;
+    }
+    
+    .container {
+      max-width: 1400px;
+      margin: 0 auto;
+      background: white;
+      border-radius: 12px;
+      box-shadow: 0 10px 40px rgba(0,0,0,0.1);
+      overflow: hidden;
+    }
+    
+    header {
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: white;
+      padding: 40px;
+      text-align: center;
+    }
+    
+    header h1 {
+      font-size: 2.5em;
+      margin-bottom: 10px;
+      font-weight: 700;
+    }
+    
+    header p {
+      font-size: 1.1em;
+      opacity: 0.9;
+    }
+    
+    .stats-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 20px;
+      padding: 30px;
+      background: #f8f9fa;
+    }
+    
+    .stat-card {
+      background: white;
+      padding: 25px;
+      border-radius: 8px;
+      text-align: center;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+      border-left: 4px solid #667eea;
+    }
+    
+    .stat-card.success {
+      border-left-color: #10b981;
+    }
+    
+    .stat-card.danger {
+      border-left-color: #ef4444;
+    }
+    
+    .stat-card.warning {
+      border-left-color: #f59e0b;
+    }
+    
+    .stat-value {
+      font-size: 2.5em;
+      font-weight: 700;
+      margin-bottom: 5px;
+    }
+    
+    .stat-label {
+      color: #6b7280;
+      font-size: 0.9em;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+    }
+    
+    .content {
+      padding: 30px;
+    }
+    
+    .chart-container {
+      margin: 30px 0;
+      padding: 20px;
+      background: #f8f9fa;
+      border-radius: 8px;
+    }
+    
+    .chart-wrapper {
+      position: relative;
+      height: 400px;
+    }
+    
+    h2 {
+      font-size: 1.8em;
+      margin-bottom: 20px;
+      color: #1f2937;
+    }
+    
+    .test-runs-table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 20px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+      border-radius: 8px;
+      overflow: hidden;
+    }
+    
+    .test-runs-table thead {
+      background: #667eea;
+      color: white;
+    }
+    
+    .test-runs-table th {
+      padding: 15px;
+      text-align: left;
+      font-weight: 600;
+    }
+    
+    .test-runs-table td {
+      padding: 12px 15px;
+      border-bottom: 1px solid #e5e7eb;
+    }
+    
+    .test-runs-table tbody tr:hover {
+      background: #f3f4f6;
+    }
+    
+    .badge {
+      display: inline-block;
+      padding: 4px 12px;
+      border-radius: 12px;
+      font-size: 0.85em;
+      font-weight: 600;
+    }
+    
+    .badge.success {
+      background: #d1fae5;
+      color: #065f46;
+    }
+    
+    .badge.warning {
+      background: #fef3c7;
+      color: #92400e;
+    }
+    
+    .badge.danger {
+      background: #fee2e2;
+      color: #991b1b;
+    }
+    
+    .link-button {
+      display: inline-block;
+      padding: 6px 14px;
+      background: #667eea;
+      color: white;
+      text-decoration: none;
+      border-radius: 6px;
+      font-size: 0.9em;
+      transition: background 0.2s;
+    }
+    
+    .link-button:hover {
+      background: #5568d3;
+    }
+    
+    .loading {
+      text-align: center;
+      padding: 60px;
+      color: #6b7280;
+      font-size: 1.2em;
+    }
+    
+    .error {
+      background: #fee2e2;
+      color: #991b1b;
+      padding: 20px;
+      border-radius: 8px;
+      margin: 20px;
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>🍦 Gino's Gelato</h1>
+      <p>Test Results Dashboard & Trends</p>
+    </header>
+    
+    <div id="stats-container" class="stats-grid">
+      <div class="loading">Loading test data...</div>
+    </div>
+    
+    <div class="content">
+      <div class="chart-container">
+        <h2>📈 Test Trend - Pass/Fail Over Time</h2>
+        <div class="chart-wrapper">
+          <canvas id="trendChart"></canvas>
+        </div>
+      </div>
+      
+      <div class="chart-container">
+        <h2>⏱️ Test Duration Trend</h2>
+        <div class="chart-wrapper">
+          <canvas id="durationChart"></canvas>
+        </div>
+      </div>
+      
+      <h2>📋 Recent Test Runs</h2>
+      <div id="test-runs-container">
+        <div class="loading">Loading test runs...</div>
+      </div>
+    </div>
+  </div>
+  
+  <script>
+    async function loadTestHistory() {
+      try {
+        const response = await fetch('./test-history.json');
+        if (!response.ok) {
+          throw new Error('No test history found');
+        }
+        const history = await response.json();
+        
+        if (!history || history.length === 0) {
+          throw new Error('No test runs recorded yet');
+        }
+        
+        renderStats(history);
+        renderTrendChart(history);
+        renderDurationChart(history);
+        renderTestRunsTable(history);
+      } catch (error) {
+        console.error('Error loading test history:', error);
+        document.getElementById('stats-container').innerHTML = `
+          <div class="error">
+            <strong>⚠️ Error Loading Test Data</strong><br>
+            ${error.message}<br>
+            <small>Run your tests to generate history data.</small>
+          </div>
+        `;
+        document.getElementById('test-runs-container').innerHTML = '';
+      }
+    }
+    
+    function renderStats(history) {
+      const latest = history[history.length - 1];
+      const totalRuns = history.length;
+      const avgPassRate = Math.round(
+        history.reduce((sum, run) => sum + run.passRate, 0) / history.length
+      );
+      
+      const statsHtml = `
+        <div class="stat-card">
+          <div class="stat-value">${totalRuns}</div>
+          <div class="stat-label">Total Runs</div>
+        </div>
+        <div class="stat-card success">
+          <div class="stat-value">${latest.passed}</div>
+          <div class="stat-label">Last Run Passed</div>
+        </div>
+        <div class="stat-card danger">
+          <div class="stat-value">${latest.failed}</div>
+          <div class="stat-label">Last Run Failed</div>
+        </div>
+        <div class="stat-card warning">
+          <div class="stat-value">${avgPassRate}%</div>
+          <div class="stat-label">Avg Pass Rate</div>
+        </div>
+      `;
+      
+      document.getElementById('stats-container').innerHTML = statsHtml;
+    }
+    
+    function renderTrendChart(history) {
+      const ctx = document.getElementById('trendChart').getContext('2d');
+      
+      // Take last 20 runs for readability
+      const recentHistory = history.slice(-20);
+      
+      new Chart(ctx, {
+        type: 'line',
+        data: {
+          labels: recentHistory.map(r => r.date),
+          datasets: [
+            {
+              label: 'Passed',
+              data: recentHistory.map(r => r.passed),
+              borderColor: '#10b981',
+              backgroundColor: 'rgba(16, 185, 129, 0.1)',
+              tension: 0.4,
+              fill: true
+            },
+            {
+              label: 'Failed',
+              data: recentHistory.map(r => r.failed),
+              borderColor: '#ef4444',
+              backgroundColor: 'rgba(239, 68, 68, 0.1)',
+              tension: 0.4,
+              fill: true
+            }
+          ]
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: {
+            legend: {
+              display: true,
+              position: 'top'
+            }
+          },
+          scales: {
+            y: {
+              beginAtZero: true,
+              ticks: {
+                stepSize: 1
+              }
+            }
+          }
+        }
+      });
+    }
+    
+    function renderDurationChart(history) {
+      const ctx = document.getElementById('durationChart').getContext('2d');
+      
+      const recentHistory = history.slice(-20);
+      
+      new Chart(ctx, {
+        type: 'bar',
+        data: {
+          labels: recentHistory.map(r => r.date),
+          datasets: [{
+            label: 'Duration (seconds)',
+            data: recentHistory.map(r => r.duration),
+            backgroundColor: 'rgba(102, 126, 234, 0.7)',
+            borderColor: '#667eea',
+            borderWidth: 1
+          }]
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: {
+            legend: {
+              display: false
+            }
+          },
+          scales: {
+            y: {
+              beginAtZero: true
+            }
+          }
+        }
+      });
+    }
+    
+    function renderTestRunsTable(history) {
+      // Show most recent runs first
+      const sortedHistory = [...history].reverse().slice(0, 10);
+      
+      const tableHtml = `
+        <table class="test-runs-table">
+          <thead>
+            <tr>
+              <th>Date</th>
+              <th>Run</th>
+              <th>Total</th>
+              <th>Passed</th>
+              <th>Failed</th>
+              <th>Pass Rate</th>
+              <th>Duration</th>
+              <th>Report</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${sortedHistory.map(run => `
+              <tr>
+                <td>${new Date(run.timestamp).toLocaleDateString()}</td>
+                <td>#${run.runNumber}</td>
+                <td><strong>${run.total}</strong></td>
+                <td><span class="badge success">${run.passed}</span></td>
+                <td>${run.failed > 0 ? `<span class="badge danger">${run.failed}</span>` : '-'}</td>
+                <td>
+                  <span class="badge ${run.passRate === 100 ? 'success' : run.passRate >= 80 ? 'warning' : 'danger'}">
+                    ${run.passRate}%
+                  </span>
+                </td>
+                <td>${run.duration}s</td>
+                <td>
+                  <a href="./reports/${run.runId}/index.html" class="link-button" target="_blank">
+                    View Report
+                  </a>
+                </td>
+              </tr>
+            `).join('')}
+          </tbody>
+        </table>
+      `;
+      
+      document.getElementById('test-runs-container').innerHTML = tableHtml;
+    }
+    
+    // Load data on page load
+    loadTestHistory();
+  </script>
+</body>
+</html>

--- a/.github/scripts/extract-test-metrics.js
+++ b/.github/scripts/extract-test-metrics.js
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+
+/**
+ * Extract test metrics from Playwright JSON results
+ * and update the test history file
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// Read Playwright JSON results
+const resultsPath = process.argv[2] || './test-results.json';
+const historyPath = process.argv[3] || './test-history.json';
+const runNumber = process.argv[4] || Date.now();
+const runUrl = process.argv[5] || '';
+
+console.log(`Reading test results from: ${resultsPath}`);
+
+let results;
+try {
+  const rawData = fs.readFileSync(resultsPath, 'utf8');
+  results = JSON.parse(rawData);
+} catch (error) {
+  console.error('Error reading test results:', error.message);
+  process.exit(1);
+}
+
+// Calculate metrics
+const suites = results.suites || [];
+const allTests = [];
+
+function extractTests(suite) {
+  if (suite.specs) {
+    suite.specs.forEach(spec => {
+      allTests.push({
+        title: spec.title,
+        ok: spec.ok,
+        tests: spec.tests || []
+      });
+    });
+  }
+  if (suite.suites) {
+    suite.suites.forEach(extractTests);
+  }
+}
+
+suites.forEach(extractTests);
+
+const total = allTests.length;
+const passed = allTests.filter(t => t.ok).length;
+const failed = total - passed;
+const duration = results.stats?.duration || 0;
+
+// Create summary object
+const summary = {
+  runId: `${new Date().toISOString().split('T')[0]}-run-${runNumber}`,
+  timestamp: new Date().toISOString(),
+  date: new Date().toISOString().split('T')[0],
+  runNumber: runNumber,
+  total: total,
+  passed: passed,
+  failed: failed,
+  skipped: 0,
+  duration: Math.round(duration / 1000), // convert to seconds
+  passRate: total > 0 ? Math.round((passed / total) * 100) : 0,
+  reportUrl: runUrl
+};
+
+console.log('Test Summary:', JSON.stringify(summary, null, 2));
+
+// Read existing history or create new
+let history = [];
+if (fs.existsSync(historyPath)) {
+  try {
+    const historyData = fs.readFileSync(historyPath, 'utf8');
+    history = JSON.parse(historyData);
+    console.log(`Loaded ${history.length} previous test runs`);
+  } catch (error) {
+    console.warn('Could not read history file, starting fresh:', error.message);
+  }
+}
+
+// Add new summary to history
+history.push(summary);
+
+// Keep only last 50 runs
+if (history.length > 50) {
+  history = history.slice(-50);
+}
+
+// Write updated history
+fs.writeFileSync(historyPath, JSON.stringify(history, null, 2));
+console.log(`Updated history with ${history.length} total runs`);
+
+// Also write just this run's summary for easy access
+fs.writeFileSync('./current-run-summary.json', JSON.stringify(summary, null, 2));
+console.log('Wrote current run summary');

--- a/.github/workflows/BuildDeploy.yml
+++ b/.github/workflows/BuildDeploy.yml
@@ -257,6 +257,60 @@ jobs:
       - name: Run Playwright Tests
         run: |
           npx playwright test
+        continue-on-error: true
+
+      - name: Checkout gh-pages branch for history
+        if: always()
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: gh-pages-content
+          
+      - name: Extract Test Metrics and Update History
+        if: always()
+        run: |
+          # Create reports directory for this run
+          RUN_ID="${{ github.run_number }}"
+          DATE=$(date +%Y-%m-%d)
+          REPORT_DIR="reports/${DATE}-run-${RUN_ID}"
+          
+          echo "Creating report directory: $REPORT_DIR"
+          mkdir -p deployment-content/$REPORT_DIR
+          
+          # Copy HTML report to dated folder
+          if [ -d "playwright-report" ]; then
+            cp -r playwright-report/* deployment-content/$REPORT_DIR/
+          fi
+          
+          # Extract metrics from JSON
+          if [ -f "test-results.json" ]; then
+            # Copy existing history if it exists
+            if [ -f "gh-pages-content/test-history.json" ]; then
+              cp gh-pages-content/test-history.json ./test-history.json
+            else
+              echo "[]" > test-history.json
+            fi
+            
+            # Extract and append metrics
+            REPORT_URL="https://pagelsr.github.io/GinosGelato/reports/${DATE}-run-${RUN_ID}"
+            node .github/scripts/extract-test-metrics.js test-results.json test-history.json $RUN_ID "$REPORT_URL"
+            
+            # Copy updated history to deployment
+            cp test-history.json deployment-content/
+            cp current-run-summary.json deployment-content/
+          fi
+          
+          # Copy dashboard as index.html
+          cp .github/pages/dashboard.html deployment-content/index.html
+          
+          # Copy existing reports if any
+          if [ -d "gh-pages-content/reports" ]; then
+            mkdir -p deployment-content/reports
+            cp -r gh-pages-content/reports/* deployment-content/reports/ || true
+          fi
+          
+          echo "Deployment structure ready"
+          ls -la deployment-content/
 
       - name: Upload Playwright Report Artifact
         if: always()
@@ -266,16 +320,17 @@ jobs:
           path: playwright-report/
           retention-days: 30
 
-      - name: Publish Playwright Report to GitHub Pages
+      - name: Publish Test Dashboard to GitHub Pages
         if: always()
         uses: peaceiris/actions-gh-pages@v3
         with:
           personal_token: ${{ secrets.PERSONAL_ACCESSTOKEN_PAGES }}
           publish_branch: gh-pages
-          publish_dir: playwright-report
-          keep_files: true
+          publish_dir: deployment-content
+          keep_files: false
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'
+          commit_message: 'Deploy test report for run #${{ github.run_number }}'
 
   post-deployment-verification:
     name: 5️⃣ Post-Deployment Verification

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,7 +22,11 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: [['list'], ['html']],
+  reporter: [
+    ['list'],
+    ['html'],
+    ['json', { outputFile: 'test-results.json' }]
+  ],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('')`. */


### PR DESCRIPTION
This pull request introduces a comprehensive test results dashboard for GitHub Pages, automates test metrics extraction and history tracking, and updates the CI workflow to publish a dashboard instead of just a single test report. These changes make it easier to monitor test trends, access historical results, and view detailed reports for each run.

**Test Dashboard and Metrics Tracking**

* Added a detailed README (`.github/pages/README.md`) describing the new Test Results Dashboard, its features, file structure, and usage.
* Introduced the `extract-test-metrics.js` script to parse Playwright JSON results, summarize metrics, and update `test-history.json` and `current-run-summary.json`, keeping the last 50 runs.

**CI Workflow Enhancements**

* Updated the Playwright config (`playwright.config.ts`) to generate a JSON report (`test-results.json`) alongside HTML and list reports.
* Modified the GitHub Actions workflow (`BuildDeploy.yml`) to:
  - Run tests and continue on error, ensuring metrics are always extracted.
  - Checkout the `gh-pages` branch, extract metrics, update history, organize reports by date/run, and prepare the deployment structure for the dashboard.
  - Publish the dashboard and all related artifacts to GitHub Pages, replacing the previous single-report publication.

**Azure Deployment Update**

* Specified `scope: resourcegroup` in the Azure deployment step for improved clarity and correctness.