### PR TITLE
Add CI/CD workflow for Build and Deploy to Azure with backend and fro…

### DIFF
--- a/.github/workflows/BuildDeploy.yml
+++ b/.github/workflows/BuildDeploy.yml
@@ -320,7 +320,7 @@ jobs:
 
       - name: Install Playwright Browsers
         run: |
-          npx playwright install --with-deps
+          npx playwright install --with-deps chromium
 
       - name: Run Playwright Tests
         run: |

--- a/.github/workflows/playwright-testing.yml
+++ b/.github/workflows/playwright-testing.yml
@@ -34,11 +34,65 @@ jobs:
 
       - name: Install Playwright Browsers
         run: |
-          npx playwright install --with-deps
+          npx playwright install --with-deps chromium
 
       - name: Run Playwright Tests
         run: |
           npx playwright test
+        continue-on-error: true
+
+      - name: Checkout gh-pages branch for history
+        if: always()
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: gh-pages-content
+          
+      - name: Extract Test Metrics and Update History
+        if: always()
+        run: |
+          # Create reports directory for this run
+          RUN_ID="${{ github.run_number }}"
+          DATE=$(date +%Y-%m-%d)
+          REPORT_DIR="reports/${DATE}-run-${RUN_ID}"
+          
+          echo "Creating report directory: $REPORT_DIR"
+          mkdir -p deployment-content/$REPORT_DIR
+          
+          # Copy HTML report to dated folder
+          if [ -d "playwright-report" ]; then
+            cp -r playwright-report/* deployment-content/$REPORT_DIR/
+          fi
+          
+          # Extract metrics from JSON
+          if [ -f "test-results.json" ]; then
+            # Copy existing history if it exists
+            if [ -f "gh-pages-content/test-history.json" ]; then
+              cp gh-pages-content/test-history.json ./test-history.json
+            else
+              echo "[]" > test-history.json
+            fi
+            
+            # Extract and append metrics
+            REPORT_URL="https://pagelsr.github.io/GinosGelato/reports/${DATE}-run-${RUN_ID}"
+            node .github/scripts/extract-test-metrics.js test-results.json test-history.json $RUN_ID "$REPORT_URL"
+            
+            # Copy updated history to deployment
+            cp test-history.json deployment-content/
+            cp current-run-summary.json deployment-content/
+          fi
+          
+          # Copy dashboard as index.html
+          cp .github/pages/dashboard.html deployment-content/index.html
+          
+          # Copy existing reports if any
+          if [ -d "gh-pages-content/reports" ]; then
+            mkdir -p deployment-content/reports
+            cp -r gh-pages-content/reports/* deployment-content/reports/ || true
+          fi
+          
+          echo "Deployment structure ready"
+          ls -la deployment-content/
 
       - name: Upload Playwright Report Artifact
         if: always()
@@ -48,24 +102,27 @@ jobs:
           path: playwright-report/
           retention-days: 30
 
-      - name: Publish Playwright Report to GitHub Pages
+      - name: Publish Test Dashboard to GitHub Pages
         if: always()
         uses: peaceiris/actions-gh-pages@v3
         with:
           personal_token: ${{ secrets.PERSONAL_ACCESSTOKEN_PAGES }}
           publish_branch: gh-pages
-          publish_dir: playwright-report
-          keep_files: true
+          publish_dir: deployment-content
+          keep_files: false
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'
+          commit_message: 'Deploy scheduled test report for run #${{ github.run_number }}'
 
       - name: Test Results Summary
         if: always()
         run: |
-          echo "## Playwright Test Results" >> $GITHUB_STEP_SUMMARY
+          echo "## 📅 Scheduled Playwright Test Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Scheduled Run - $(date)" >> $GITHUB_STEP_SUMMARY
+          echo "**Run Date:** $(date)" >> $GITHUB_STEP_SUMMARY
+          echo "**Run Number:** #${{ github.run_number }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Test report published to GitHub Pages" >> $GITHUB_STEP_SUMMARY
+          echo "### 📊 View Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "📊 [View Full Report](https://pagelsr.github.io/GinosGelato/)" >> $GITHUB_STEP_SUMMARY
+          echo "- **Dashboard:** https://pagelsr.github.io/GinosGelato/" >> $GITHUB_STEP_SUMMARY
+          echo "- **This Run:** https://pagelsr.github.io/GinosGelato/reports/$(date +%Y-%m-%d)-run-${{ github.run_number }}/" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to introduce a dedicated build-and-test job for pull request validation and restricts deployment and testing jobs to run only on pushes to the `main` branch. These changes help ensure that code is validated before merging and deployments only happen from the main branch.

Workflow improvements for PR validation and deployment control:

* Added a new `build-and-test` job that runs on pull requests, performing backend and frontend build and test steps, and summarizes results for PR validation. (`.github/workflows/BuildDeploy.yml`)

Deployment and testing jobs restricted to main branch:

* Updated `provision-infrastructure`, `build-and-deploy-backend`, `build-and-deploy-frontend`, `run-playwright-tests`, and `post-deployment-verification` jobs to only run on pushes to the `main` branch by adding `if` conditions. (`.github/workflows/BuildDeploy.yml`) [[1]](diffhunk://#diff-79ead85d46b2bc01c39c212f3a57de45c83bcf553e4022d831507502871ab1c9R29-R96) [[2]](diffhunk://#diff-79ead85d46b2bc01c39c212f3a57de45c83bcf553e4022d831507502871ab1c9R140) [[3]](diffhunk://#diff-79ead85d46b2bc01c39c212f3a57de45c83bcf553e4022d831507502871ab1c9R225) [[4]](diffhunk://#diff-79ead85d46b2bc01c39c212f3a57de45c83bcf553e4022d831507502871ab1c9R299) [[5]](diffhunk://#diff-79ead85d46b2bc01c39c212f3a57de45c83bcf553e4022d831507502871ab1c9R404)

Dependency management and job sequencing:

* Added `needs: build-and-test` to `provision-infrastructure` to ensure infrastructure provisioning only happens after successful build and test validation. (`.github/workflows/BuildDeploy.yml`)

These changes collectively improve CI/CD pipeline reliability by validating code before deployment and preventing accidental deployments from non-main branches.