### PR TITLE
Update dashboard to correctly display failed test counts and adjust P…

### DIFF
--- a/.github/pages/dashboard.html
+++ b/.github/pages/dashboard.html
@@ -478,7 +478,7 @@
                 <td>#${run.runNumber}</td>
                 <td><strong>${run.total}</strong></td>
                 <td><span class="badge success">${run.passed}</span></td>
-                <td>${run.failed > 0 ? `<span class="badge danger">${run.failed - (run.flaky || 0)}</span>` : '-'}</td>
+                <td>${run.failed - (run.flaky || 0) > 0 ? `<span class="badge danger">${run.failed - (run.flaky || 0)}</span>` : '-'}</td>
                 <td>${(run.flaky || 0) > 0 ? `<span class="badge warning">${run.flaky}</span>` : '-'}</td>
                 <td>
                   <span class="badge ${run.passRate === 100 ? 'success' : run.passRate >= 80 ? 'warning' : 'danger'}">

--- a/.github/workflows/playwright-testing.yml
+++ b/.github/workflows/playwright-testing.yml
@@ -3,7 +3,9 @@ name: Playwright Testing - Daily Schedule
 on:
   schedule:
     # Runs daily at 6:00 AM EST (11:00 AM UTC)
-    - cron: '0 11 * * *'
+    # - cron: '0 11 * * *'
+    # Runs every 2 hours for test data generation
+    - cron: '0 */2 * * *'
   workflow_dispatch: # Allows manual trigger from GitHub Actions UI
 
 env:


### PR DESCRIPTION
This pull request makes adjustments to the Playwright testing workflow schedule and improves the logic for displaying failed test counts on the dashboard. The workflow now runs more frequently for better test data generation, and the dashboard more accurately shows failed test numbers by properly accounting for flaky tests.

Workflow scheduling changes:

* [`.github/workflows/playwright-testing.yml`](diffhunk://#diff-0c74489c80309c27fce96996b783c190024017cd4addbec67353fbfd18707f2eL6-R8): Changed the scheduled workflow to run every 2 hours instead of once daily, supporting more frequent test data generation.

Dashboard logic improvements:

* [`.github/pages/dashboard.html`](diffhunk://#diff-2516ba74140defd7206a959bd92afeba8df9c0704a9a1762afbbc7fb1365e1b7L481-R481): Updated the logic for displaying failed test counts to ensure the number shown excludes flaky tests and only displays a badge if the adjusted failed count is greater than zero.