### PR TITLE
Update dashboard to calculate actual failures excluding flaky tests

### DIFF
--- a/.github/pages/dashboard.html
+++ b/.github/pages/dashboard.html
@@ -274,6 +274,9 @@
       );
       const totalFlaky = history.reduce((sum, run) => sum + (run.flaky || 0), 0);
       
+      // Calculate actual failures (excluding flaky) for consistency with table display
+      const actualFailed = latest.failed - (latest.flaky || 0);
+      
       const statsHtml = `
         <div class="stat-card">
           <div class="stat-value">${totalRuns}</div>
@@ -284,7 +287,7 @@
           <div class="stat-label">Last Run Passed</div>
         </div>
         <div class="stat-card danger">
-          <div class="stat-value">${latest.failed}</div>
+          <div class="stat-value">${actualFailed}</div>
           <div class="stat-label">Last Run Failed</div>
         </div>
         <div class="stat-card warning">


### PR DESCRIPTION
This pull request updates the test run statistics section in the `.github/pages/dashboard.html` dashboard to improve accuracy and consistency. The main change is that the "Last Run Failed" statistic now excludes flaky tests, matching the way failures are displayed in the table.

Improvements to test run statistics:

* Calculated `actualFailed` by subtracting flaky tests from failed tests to display the true number of failures for the latest run. (`.github/pages/dashboard.html`)
* Updated the "Last Run Failed" stat card to use `actualFailed` instead of the raw failed count, ensuring consistency with the table display. (`.github/pages/dashboard.html`)