### PR TITLE
Update Playwright testing schedule to run weekly on Fridays

### DIFF
--- a/.github/workflows/playwright-testing.yml
+++ b/.github/workflows/playwright-testing.yml
@@ -1,9 +1,9 @@
-name: Playwright Testing - Daily Schedule
+name: Playwright Testing - Weekly Schedule
 
 on:
   schedule:
-    # Runs daily at 6:00 AM EST (11:00 AM UTC)
-    - cron: '0 11 * * *'
+    # Runs weekly on Friday at 6:00 AM EST (11:00 AM UTC)
+    - cron: '0 11 * * 5'
     # Runs every 2 hours for test data generation
     # - cron: '0 */2 * * *'
   workflow_dispatch: # Allows manual trigger from GitHub Actions UI


### PR DESCRIPTION
This pull request updates the Playwright testing workflow schedule to reduce the frequency of automated runs. The workflow now runs weekly instead of daily.

Workflow schedule update:

* Changed the Playwright testing workflow in `.github/workflows/playwright-testing.yml` to run weekly on Fridays at 6:00 AM EST (11:00 AM UTC) instead of daily.