### PR TITLE
Enable Swagger UI in all environments for consistent API documentatio…

### DIFF
--- a/ginos-gelato/server/Program.cs
+++ b/ginos-gelato/server/Program.cs
@@ -36,11 +36,8 @@ builder.Services.AddCors(options =>
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
-if (app.Environment.IsDevelopment())
-{
-    app.UseSwagger();
-    app.UseSwaggerUI();
-}
+app.UseSwagger();
+app.UseSwaggerUI();
 
 app.UseHttpsRedirection();
 


### PR DESCRIPTION
This pull request updates the Swagger configuration in `Program.cs` to always enable the Swagger UI, regardless of the environment. Previously, Swagger was only enabled in development.

Configuration changes:

* [`Program.cs`](diffhunk://#diff-7ccaba574b5b54268c7a54bd2d7d77584f1b3b0cc5ade09ca0963d0dc8ea09ecL39-L43): Removed the check for development environment so that `app.UseSwagger()` and `app.UseSwaggerUI()` are always called.