### PR TITLE
Disable load testing

### DIFF
--- a/.github/workflows/BuildDeploy.yml
+++ b/.github/workflows/BuildDeploy.yml
@@ -407,7 +407,7 @@ jobs:
 
   run-load-tests:
     name: 5️⃣ Run Azure Load Tests
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: false # TODO: Re-enable when Azure Load Testing resource is provisioned
     runs-on: ubuntu-latest
     needs: [provision-infrastructure, run-playwright-tests]
 
@@ -467,7 +467,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     name: 6️⃣ Post-Deployment Verification
     runs-on: ubuntu-latest
-    needs: [provision-infrastructure, build-and-deploy-backend, build-and-deploy-frontend, run-playwright-tests, run-load-tests]
+    needs: [provision-infrastructure, build-and-deploy-backend, build-and-deploy-frontend, run-playwright-tests]
     
     steps:
       - name: Azure Login

--- a/.github/workflows/BuildDeploy.yml
+++ b/.github/workflows/BuildDeploy.yml
@@ -92,7 +92,7 @@ jobs:
   provision-infrastructure:
     name: 1️⃣ Provision Infrastructure (Bicep/IaC)
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
     needs: build-and-test
     outputs:
       resourceGroupName: ${{ env.RESOURCE_GROUP }}
@@ -139,7 +139,7 @@ jobs:
   build-and-deploy-backend:
     name: 2️⃣ Build, Test & Deploy Backend API
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
     needs: [provision-infrastructure]
     
     steps:
@@ -224,7 +224,7 @@ jobs:
 
   build-and-deploy-frontend:
     name: 3️⃣ Build & Deploy Frontend (Static Web App)
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: [provision-infrastructure, build-and-deploy-backend]
     
@@ -301,7 +301,7 @@ jobs:
 
   run-playwright-tests:
     name: 4️⃣ Run Playwright Tests
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: [build-and-deploy-frontend]
     env:
@@ -464,7 +464,7 @@ jobs:
           echo "📊 Download the **load-test-results** artifact for full JMeter report" >> $GITHUB_STEP_SUMMARY
 
   post-deployment-verification:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
     name: 6️⃣ Post-Deployment Verification
     runs-on: ubuntu-latest
     needs: [provision-infrastructure, build-and-deploy-backend, build-and-deploy-frontend, run-playwright-tests]


### PR DESCRIPTION
This pull request updates the `.github/workflows/BuildDeploy.yml` workflow to provide more flexibility in how the pipeline is triggered and to temporarily disable the Azure Load Tests job. The main changes are to allow manual workflow dispatches in addition to pushes to `main`, and to prevent the load test job from running until the necessary resources are available.

**Workflow trigger improvements:**

* Updated the `if` condition for the following jobs to allow them to run on both `push` and `workflow_dispatch` events, as long as the branch is `main`: `provision-infrastructure`, `build-and-deploy-backend`, `build-and-deploy-frontend`, `run-playwright-tests`, and `post-deployment-verification`. [[1]](diffhunk://#diff-79ead85d46b2bc01c39c212f3a57de45c83bcf553e4022d831507502871ab1c9L95-R95) [[2]](diffhunk://#diff-79ead85d46b2bc01c39c212f3a57de45c83bcf553e4022d831507502871ab1c9L142-R142) [[3]](diffhunk://#diff-79ead85d46b2bc01c39c212f3a57de45c83bcf553e4022d831507502871ab1c9L227-R227) [[4]](diffhunk://#diff-79ead85d46b2bc01c39c212f3a57de45c83bcf553e4022d831507502871ab1c9L304-R304) [[5]](diffhunk://#diff-79ead85d46b2bc01c39c212f3a57de45c83bcf553e4022d831507502871ab1c9L467-R470)

**Load test job changes:**

* Disabled the `run-load-tests` job by setting its `if` condition to `false`, with a TODO comment to re-enable it once the Azure Load Testing resource is provisioned. Also removed it from the dependencies of the `post-deployment-verification` job. [[1]](diffhunk://#diff-79ead85d46b2bc01c39c212f3a57de45c83bcf553e4022d831507502871ab1c9L410-R410) [[2]](diffhunk://#diff-79ead85d46b2bc01c39c212f3a57de45c83bcf553e4022d831507502871ab1c9L467-R470)